### PR TITLE
Remove bad characters from shell script

### DIFF
--- a/docker-compose.sh
+++ b/docker-compose.sh
@@ -8,7 +8,7 @@ if [ ! -x /usr/bin/docker ]; then
 	sudo sh -c "echo deb https://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
 	sudo apt-get update
 	sudo apt-get -qqy install lxc-docker
-	sudo usermod -a -G docker `id -g -n`  # för att slippa köra docker med sudo
+	sudo usermod -a -G docker `id -g -n`  # avoid running docker with sudo
 fi
 
 #Installing Compose


### PR DESCRIPTION
Remove bad characters from shell script.

Those characters caused me to get this error (on OSX):

```
==> default: Running cleanup tasks for 'shell' provisioner...
==> default: Running cleanup tasks for 'shell' provisioner...
/opt/vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/provisioners/shell/provisioner.rb:179:in `gsub!': invalid byte sequence in UTF-8 (ArgumentError)
    from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/provisioners/shell/provisioner.rb:179:in `with_script_file'
```
